### PR TITLE
Update `Website` key in `plugin.json`

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
   "Author": "Garulf",
   "Version": "1.0.2",
   "Language": "python",
-  "Website": "https://github.com/garulf/windows_startup",
+  "Website": "https://github.com/Garulf/Windows-Startup",
   "IcoPath": "./icons/application.png",
   "ExecuteFileName": "run.py"
 }


### PR DESCRIPTION
The `Website` key in the `plugin.json` file points to a 404 page, the repo seems to have been renamed since the key was last updated